### PR TITLE
Check if installer uses InstallerV1 while spec is 0

### DIFF
--- a/src/main/java/io/github/zekerzhayard/forgewrapper/installer/Installer.java
+++ b/src/main/java/io/github/zekerzhayard/forgewrapper/installer/Installer.java
@@ -1,12 +1,14 @@
 package io.github.zekerzhayard.forgewrapper.installer;
 
 import java.io.File;
+import java.lang.reflect.Method;
 
 import io.github.zekerzhayard.forgewrapper.installer.util.AbstractInstaller;
 import io.github.zekerzhayard.forgewrapper.installer.util.InstallerV0;
 import io.github.zekerzhayard.forgewrapper.installer.util.InstallerV1;
 import net.minecraftforge.installer.actions.ProgressCallback;
 import net.minecraftforge.installer.json.Install;
+import net.minecraftforge.installer.json.Util;
 
 public class Installer {
     public static boolean install(File libraryDir, File minecraftJar, File installerJar, int installerSpec) {
@@ -26,7 +28,18 @@ public class Installer {
 
     private static AbstractInstaller getInstaller(int installerSpec) {
         switch (installerSpec) {
-            case 0: return new InstallerV0();
+            case 0: {
+                Boolean isV1 = false;
+                Method[] methods = Util.class.getDeclaredMethods();
+                for (Method method: methods) {
+                    String methodName = method.toString();
+                    if (methodName.contains("InstallV1") && methodName.contains("loadInstallProfile")) {
+                        isV1 = true;
+                        break;
+                    }
+                }
+                return isV1 ? new InstallerV1() : new InstallerV0();
+            }
             case 1: return new InstallerV1();
             default: throw new IllegalArgumentException("Invalid installer profile spec: " + installerSpec);
         }

--- a/src/main/java/io/github/zekerzhayard/forgewrapper/installer/Installer.java
+++ b/src/main/java/io/github/zekerzhayard/forgewrapper/installer/Installer.java
@@ -1,7 +1,6 @@
 package io.github.zekerzhayard.forgewrapper.installer;
 
 import java.io.File;
-import java.lang.reflect.Method;
 
 import io.github.zekerzhayard.forgewrapper.installer.util.AbstractInstaller;
 import io.github.zekerzhayard.forgewrapper.installer.util.InstallerV0;
@@ -11,10 +10,10 @@ import net.minecraftforge.installer.json.Install;
 import net.minecraftforge.installer.json.Util;
 
 public class Installer {
-    public static boolean install(File libraryDir, File minecraftJar, File installerJar, int installerSpec) {
-        AbstractInstaller installer = getInstaller(installerSpec);
+    public static boolean install(File libraryDir, File minecraftJar, File installerJar) {
+        Install profile = Util.loadInstallProfile();
+        AbstractInstaller installer = getInstaller(profile);
         ProgressCallback monitor = ProgressCallback.withOutputs(System.out);
-        Install profile = installer.loadInstallProfile();
         if (System.getProperty("java.net.preferIPv4Stack") == null) {
             System.setProperty("java.net.preferIPv4Stack", "true");
         }
@@ -26,22 +25,7 @@ public class Installer {
         return installer.runClientInstall(profile, monitor, libraryDir, minecraftJar, installerJar);
     }
 
-    private static AbstractInstaller getInstaller(int installerSpec) {
-        switch (installerSpec) {
-            case 0: {
-                Boolean isV1 = false;
-                Method[] methods = Util.class.getDeclaredMethods();
-                for (Method method: methods) {
-                    String methodName = method.toString();
-                    if (methodName.contains("InstallV1") && methodName.contains("loadInstallProfile")) {
-                        isV1 = true;
-                        break;
-                    }
-                }
-                return isV1 ? new InstallerV1() : new InstallerV0();
-            }
-            case 1: return new InstallerV1();
-            default: throw new IllegalArgumentException("Invalid installer profile spec: " + installerSpec);
-        }
+    private static AbstractInstaller getInstaller(Install profile) {
+        return profile.getClass().toString().contains("InstallV1") ? new InstallerV1() : new InstallerV0();
     }
 }

--- a/src/main/java/io/github/zekerzhayard/forgewrapper/installer/Installer.java
+++ b/src/main/java/io/github/zekerzhayard/forgewrapper/installer/Installer.java
@@ -1,6 +1,7 @@
 package io.github.zekerzhayard.forgewrapper.installer;
 
 import java.io.File;
+import java.lang.reflect.Method;
 
 import io.github.zekerzhayard.forgewrapper.installer.util.AbstractInstaller;
 import io.github.zekerzhayard.forgewrapper.installer.util.InstallerV0;
@@ -10,10 +11,10 @@ import net.minecraftforge.installer.json.Install;
 import net.minecraftforge.installer.json.Util;
 
 public class Installer {
-    public static boolean install(File libraryDir, File minecraftJar, File installerJar) {
-        Install profile = Util.loadInstallProfile();
-        AbstractInstaller installer = getInstaller(profile);
+    public static boolean install(File libraryDir, File minecraftJar, File installerJar, int installerSpec) {
+        AbstractInstaller installer = getInstaller(installerSpec);
         ProgressCallback monitor = ProgressCallback.withOutputs(System.out);
+        Install profile = installer.loadInstallProfile();
         if (System.getProperty("java.net.preferIPv4Stack") == null) {
             System.setProperty("java.net.preferIPv4Stack", "true");
         }
@@ -25,7 +26,22 @@ public class Installer {
         return installer.runClientInstall(profile, monitor, libraryDir, minecraftJar, installerJar);
     }
 
-    private static AbstractInstaller getInstaller(Install profile) {
-        return profile.getClass().toString().contains("InstallV1") ? new InstallerV1() : new InstallerV0();
+    private static AbstractInstaller getInstaller(int installerSpec) {
+        switch (installerSpec) {
+            case 0: {
+                Boolean isV1 = false;
+                Method[] methods = Util.class.getDeclaredMethods();
+                for (Method method: methods) {
+                    String methodName = method.toString();
+                    if (methodName.contains("InstallV1") && methodName.contains("loadInstallProfile")) {
+                        isV1 = true;
+                        break;
+                    }
+                }
+                return isV1 ? new InstallerV1() : new InstallerV0();
+            }
+            case 1: return new InstallerV1();
+            default: throw new IllegalArgumentException("Invalid installer profile spec: " + installerSpec);
+        }
     }
 }

--- a/src/main/java/io/github/zekerzhayard/forgewrapper/installer/Main.java
+++ b/src/main/java/io/github/zekerzhayard/forgewrapper/installer/Main.java
@@ -47,7 +47,7 @@ public class Main {
                 installerJar.toUri().toURL()
             }, ModuleUtil.getPlatformClassLoader())) {
                 Class<?> installer = ucl.loadClass("io.github.zekerzhayard.forgewrapper.installer.Installer");
-                if (!(boolean) installer.getMethod("install", File.class, File.class, File.class, int.class).invoke(null, detector.getLibraryDir().toFile(), minecraftJar.toFile(), installerJar.toFile(), detector.getInstallProfileSpec(forgeFullVersion))) {
+                if (!(boolean) installer.getMethod("install", File.class, File.class, File.class).invoke(null, detector.getLibraryDir().toFile(), minecraftJar.toFile(), installerJar.toFile())) {
                     return;
                 }
             }

--- a/src/main/java/io/github/zekerzhayard/forgewrapper/installer/Main.java
+++ b/src/main/java/io/github/zekerzhayard/forgewrapper/installer/Main.java
@@ -47,7 +47,7 @@ public class Main {
                 installerJar.toUri().toURL()
             }, ModuleUtil.getPlatformClassLoader())) {
                 Class<?> installer = ucl.loadClass("io.github.zekerzhayard.forgewrapper.installer.Installer");
-                if (!(boolean) installer.getMethod("install", File.class, File.class, File.class).invoke(null, detector.getLibraryDir().toFile(), minecraftJar.toFile(), installerJar.toFile())) {
+                if (!(boolean) installer.getMethod("install", File.class, File.class, File.class, int.class).invoke(null, detector.getLibraryDir().toFile(), minecraftJar.toFile(), installerJar.toFile(), detector.getInstallProfileSpec(forgeFullVersion))) {
                     return;
                 }
             }


### PR DESCRIPTION
Fixes the following error when trying to launch from a fresh install.

Error is caused by spec being defined as 0 while using `InstallV1`

```java
Missing: C:\Users\pierc\OneDrive\Desktop\Coding\minecraft1\libraries\net\minecraft\client\1.16.5-20210115.111550\client-1.16.5-20210115.111550-slim.jar
Some extra libraries are missing! Running the installer to generate them now.

Exception in thread "main"
java.lang.reflect.InvocationTargetException
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
        at java.base/java.lang.reflect.Method.invoke(Unknown Source)

        at io.github.zekerzhayard.forgewrapper.installer.Main.main(Main.java:50)
Caused by: java.lang.NoSuchMethodError: 'net.minecraftforge.installer.json.Install net.minecraftforge.installer.json.Util.loadInstallProfile()'
        at io.github.zekerzhayard.forgewrapper.installer.util.InstallerV0.loadInstallProfile(InstallerV0.java:14)
        at io.github.zekerzhayard.forgewrapper.installer.Installer.install(Installer.java:15)
        ... 5 more
```