### PR TITLE
Implement support for NeoForge

### DIFF
--- a/converter/src/main/java/io/github/zekerzhayard/forgewrapper/converter/Converter.java
+++ b/converter/src/main/java/io/github/zekerzhayard/forgewrapper/converter/Converter.java
@@ -28,7 +28,7 @@ public class Converter {
         JsonObject installProfile = getJsonFromZip(installerPath, "install_profile.json");
         List<String> arguments = getAdditionalArgs(installer);
         String mcVersion = arguments.get(arguments.indexOf("--fml.mcVersion") + 1);
-        String forgeGroup = arguments.get(arguments.indexOf("--fml.forgeGroup") + 1);
+        String forgeGroup = arguments.contains("--fml.forgeGroup") ? arguments.get(arguments.indexOf("--fml.forgeGroup") + 1) : "net.neoforged";
         String forgeVersion = arguments.get(arguments.indexOf("--fml.forgeVersion") + 1);
         String forgeFullVersion = "forge-" + mcVersion + "-" + forgeVersion;
         StringBuilder wrapperVersion = new StringBuilder();

--- a/converter/src/main/resources/mmc-pack.json
+++ b/converter/src/main/resources/mmc-pack.json
@@ -7,7 +7,7 @@
       "version": "{VERSION}"
     },
     {
-      "uid": "net.minecraftforge"
+      "uid": "{FORGE_GROUP}"
     }
   ]
 }

--- a/converter/src/main/resources/patches/template.json
+++ b/converter/src/main/resources/patches/template.json
@@ -10,12 +10,12 @@
     }
   ],
   "type": "release",
-  "uid": "net.minecraftforge",
+  "uid": "{FORGE_GROUP}",
   "version": "{FORGE_VERSION}",
   "mavenFiles": [
     {
-      "name": "net.minecraftforge:forge:{VERSION}-{FORGE_VERSION}:installer",
-      "url": "https://maven.minecraftforge.net/"
+      "name": "{FORGE_GROUP}:forge:{VERSION}-{FORGE_VERSION}:installer",
+      "url": "{MAVEN_URL}"
     }
   ],
   "libraries": [

--- a/legacy/build.gradle
+++ b/legacy/build.gradle
@@ -4,6 +4,11 @@ plugins {
     id "eclipse"
 }
 
+sourceCompatibility = targetCompatibility = 1.8
+compileJava {
+    sourceCompatibility = targetCompatibility = 1.8
+}
+
 repositories {
     mavenCentral()
     maven {

--- a/src/main/java/io/github/zekerzhayard/forgewrapper/installer/Main.java
+++ b/src/main/java/io/github/zekerzhayard/forgewrapper/installer/Main.java
@@ -17,20 +17,21 @@ public class Main {
     public static void main(String[] args) throws Throwable {
         List<String> argsList = Stream.of(args).collect(Collectors.toList());
         String mcVersion = argsList.get(argsList.indexOf("--fml.mcVersion") + 1);
+        String forgeGroup = argsList.get(argsList.indexOf("--fml.forgeGroup") + 1);
         String forgeVersion = argsList.get(argsList.indexOf("--fml.forgeVersion") + 1);
         String forgeFullVersion = mcVersion + "-" + forgeVersion;
 
         IFileDetector detector = DetectorLoader.loadDetector();
         try {
-            Bootstrap.bootstrap(detector.getJvmArgs(forgeFullVersion), detector.getMinecraftJar(mcVersion).getFileName().toString(), detector.getLibraryDir().toAbsolutePath().toString());
+            Bootstrap.bootstrap(detector.getJvmArgs(forgeGroup, forgeFullVersion), detector.getMinecraftJar(mcVersion).getFileName().toString(), detector.getLibraryDir().toAbsolutePath().toString());
         } catch (Throwable ignored) {
             // Avoid this bunch of hacks that nuke the whole wrapper.
         }
-        if (!detector.checkExtraFiles(forgeFullVersion)) {
+        if (!detector.checkExtraFiles(forgeGroup, forgeFullVersion)) {
             System.out.println("Some extra libraries are missing! Running the installer to generate them now.");
 
             // Check installer jar.
-            Path installerJar = detector.getInstallerJar(forgeFullVersion);
+            Path installerJar = detector.getInstallerJar(forgeGroup, forgeFullVersion);
             if (!IFileDetector.isFile(installerJar)) {
                 throw new RuntimeException("Unable to detect the forge installer!");
             }
@@ -53,7 +54,7 @@ public class Main {
             }
         }
 
-        Class<?> mainClass = ModuleUtil.setupBootstrapLauncher(Class.forName(detector.getMainClass(forgeFullVersion)));
+        Class<?> mainClass = ModuleUtil.setupBootstrapLauncher(Class.forName(detector.getMainClass(forgeGroup, forgeFullVersion)));
         mainClass.getMethod("main", String[].class).invoke(null, new Object[] { args });
     }
 }

--- a/src/main/java/io/github/zekerzhayard/forgewrapper/installer/Main.java
+++ b/src/main/java/io/github/zekerzhayard/forgewrapper/installer/Main.java
@@ -17,7 +17,7 @@ public class Main {
     public static void main(String[] args) throws Throwable {
         List<String> argsList = Stream.of(args).collect(Collectors.toList());
         String mcVersion = argsList.get(argsList.indexOf("--fml.mcVersion") + 1);
-        String forgeGroup = argsList.get(argsList.indexOf("--fml.forgeGroup") + 1);
+        String forgeGroup = argsList.contains("--fml.forgeGroup") ? argsList.get(argsList.indexOf("--fml.forgeGroup") + 1) : "net.neoforged";
         String forgeVersion = argsList.get(argsList.indexOf("--fml.forgeVersion") + 1);
         String forgeFullVersion = mcVersion + "-" + forgeVersion;
 

--- a/src/main/java/io/github/zekerzhayard/forgewrapper/installer/detector/IFileDetector.java
+++ b/src/main/java/io/github/zekerzhayard/forgewrapper/installer/detector/IFileDetector.java
@@ -64,7 +64,7 @@ public interface IFileDetector {
      * @param forgeFullVersion Forge full version (e.g. 1.14.4-28.2.0).
      * @return The forge installer jar path. It can also be defined by JVM argument "-Dforgewrapper.installer=&lt;installer-path&gt;".
      */
-    default Path getInstallerJar(String forgeFullVersion) {
+    default Path getInstallerJar(String forgeGroup, String forgeFullVersion) {
         String installer = System.getProperty("forgewrapper.installer");
         if (installer != null) {
             return Paths.get(installer).toAbsolutePath();
@@ -88,8 +88,8 @@ public interface IFileDetector {
      * @param forgeFullVersion Forge full version (e.g. 1.14.4-28.2.0).
      * @return The list of jvm args.
      */
-    default List<String> getJvmArgs(String forgeFullVersion) {
-        return this.getDataFromInstaller(forgeFullVersion, "version.json", e -> {
+    default List<String> getJvmArgs(String forgeGroup, String forgeFullVersion) {
+        return this.getDataFromInstaller(forgeGroup, forgeFullVersion, "version.json", e -> {
             JsonElement element = getElement(e.getAsJsonObject().getAsJsonObject("arguments"), "jvm");
             List<String> args = new ArrayList<>();
             if (!element.equals(JsonNull.INSTANCE)) {
@@ -103,21 +103,21 @@ public interface IFileDetector {
      * @param forgeFullVersion Forge full version (e.g. 1.14.4-28.2.0).
      * @return The main class.
      */
-    default String getMainClass(String forgeFullVersion) {
-        return this.getDataFromInstaller(forgeFullVersion, "version.json", e -> e.getAsJsonObject().getAsJsonPrimitive("mainClass").getAsString());
+    default String getMainClass(String forgeGroup, String forgeFullVersion) {
+        return this.getDataFromInstaller(forgeGroup, forgeFullVersion, "version.json", e -> e.getAsJsonObject().getAsJsonPrimitive("mainClass").getAsString());
     }
 
     /**
      * @param forgeFullVersion Forge full version (e.g. 1.14.4-28.2.0).
      * @return The json object in the-installer-jar-->install_profile.json-->data-->xxx-->client.
      */
-    default JsonObject getInstallProfileExtraData(String forgeFullVersion) {
-        return this.getDataFromInstaller(forgeFullVersion, "install_profile.json", e -> e.getAsJsonObject().getAsJsonObject("data"));
+    default JsonObject getInstallProfileExtraData(String forgeGroup, String forgeFullVersion) {
+        return this.getDataFromInstaller(forgeGroup, forgeFullVersion, "install_profile.json", e -> e.getAsJsonObject().getAsJsonObject("data"));
     }
 
     @SuppressWarnings("deprecation")
-    default <R> R getDataFromInstaller(String forgeFullVersion, String entry, Function<JsonElement, R> function) {
-        Path installer = this.getInstallerJar(forgeFullVersion);
+    default <R> R getDataFromInstaller(String forgeGroup, String forgeFullVersion, String entry, Function<JsonElement, R> function) {
+        Path installer = this.getInstallerJar(forgeGroup, forgeFullVersion);
         if (isFile(installer)) {
             try (ZipFile zf = new ZipFile(installer.toFile())) {
                 ZipEntry ze = zf.getEntry(entry);
@@ -143,8 +143,8 @@ public interface IFileDetector {
      * @param forgeFullVersion Forge full version (e.g. 1.14.4-28.2.0).
      * @return True represents all files are ready.
      */
-    default boolean checkExtraFiles(String forgeFullVersion) {
-        JsonObject jo = this.getInstallProfileExtraData(forgeFullVersion);
+    default boolean checkExtraFiles(String forgeGroup, String forgeFullVersion) {
+        JsonObject jo = this.getInstallProfileExtraData(forgeGroup, forgeFullVersion);
         if (jo != null) {
             Map<String, Path> libsMap = new HashMap<>();
             Map<String, String> hashMap = new HashMap<>();

--- a/src/main/java/io/github/zekerzhayard/forgewrapper/installer/detector/IFileDetector.java
+++ b/src/main/java/io/github/zekerzhayard/forgewrapper/installer/detector/IFileDetector.java
@@ -61,6 +61,7 @@ public interface IFileDetector {
     }
 
     /**
+     * @param forgeGroup Forge package group (e.g. net.minecraftforge).
      * @param forgeFullVersion Forge full version (e.g. 1.14.4-28.2.0).
      * @return The forge installer jar path. It can also be defined by JVM argument "-Dforgewrapper.installer=&lt;installer-path&gt;".
      */
@@ -85,6 +86,7 @@ public interface IFileDetector {
     }
 
     /**
+     * @param forgeGroup Forge package group (e.g. net.minecraftforge).
      * @param forgeFullVersion Forge full version (e.g. 1.14.4-28.2.0).
      * @return The list of jvm args.
      */
@@ -100,6 +102,7 @@ public interface IFileDetector {
     }
 
     /**
+     * @param forgeGroup Forge package group (e.g. net.minecraftforge).
      * @param forgeFullVersion Forge full version (e.g. 1.14.4-28.2.0).
      * @return The main class.
      */
@@ -108,6 +111,7 @@ public interface IFileDetector {
     }
 
     /**
+     * @param forgeGroup Forge package group (e.g. net.minecraftforge).
      * @param forgeFullVersion Forge full version (e.g. 1.14.4-28.2.0).
      * @return The json object in the-installer-jar-->install_profile.json-->data-->xxx-->client.
      */
@@ -140,6 +144,7 @@ public interface IFileDetector {
 
     /**
      * Check all cached files.
+     * @param forgeGroup Forge package group (e.g. net.minecraftforge).
      * @param forgeFullVersion Forge full version (e.g. 1.14.4-28.2.0).
      * @return True represents all files are ready.
      */

--- a/src/main/java/io/github/zekerzhayard/forgewrapper/installer/detector/MultiMCFileDetector.java
+++ b/src/main/java/io/github/zekerzhayard/forgewrapper/installer/detector/MultiMCFileDetector.java
@@ -27,10 +27,16 @@ public class MultiMCFileDetector implements IFileDetector {
     }
 
     @Override
-    public Path getInstallerJar(String forgeFullVersion) {
-        Path path = IFileDetector.super.getInstallerJar(forgeFullVersion);
+    public Path getInstallerJar(String forgeGroup, String forgeFullVersion) {
+        Path path = IFileDetector.super.getInstallerJar(forgeGroup, forgeFullVersion);
         if (path == null) {
-            return this.installerJar != null ? this.installerJar : (this.installerJar = this.getLibraryDir().resolve("net").resolve("minecraftforge").resolve("forge").resolve(forgeFullVersion).resolve("forge-" + forgeFullVersion + "-installer.jar").toAbsolutePath());
+            if (this.installerJar == null) {
+                Path installerBase = this.getLibraryDir();
+                for (String dir : forgeGroup.split("\\."))
+                    installerBase = installerBase.resolve(dir);
+                this.installerJar = installerBase.resolve("forge").resolve(forgeFullVersion).resolve("forge-" + forgeFullVersion + "-installer.jar").toAbsolutePath();
+            }
+            return this.installerJar;
         }
         return path;
     }


### PR DESCRIPTION
This PR allows for ForgeWrapper to launch NeoForge just as it launches Minecraft Forge. This is mainly accomplished using Forge's `fml.forgeGroup` launch argument, which specifies the base path of Forge-related packages; for Minecraft Forge, this has always been `net.minecraftforge`, whereas NeoForge could use `net.neoforged`. With this PR, ForgeWrapper now stores the value of this flag and uses it when determining the path to the Forge installer.

Additionally, this PR fixes a bug preventing ForgeWrapper from compiling on Java versions newer than Java 8, which I found useful developing using Java 17.

Resolves #12.