### PR TITLE
Implement support for NeoForge 20.2+

### DIFF
--- a/src/main/java/io/github/zekerzhayard/forgewrapper/installer/Main.java
+++ b/src/main/java/io/github/zekerzhayard/forgewrapper/installer/Main.java
@@ -15,23 +15,31 @@ import io.github.zekerzhayard.forgewrapper.installer.util.ModuleUtil;
 
 public class Main {
     public static void main(String[] args) throws Throwable {
+        // --fml.neoForgeVersion 20.2.20-beta --fml.fmlVersion 1.0.2 --fml.mcVersion 1.20.2 --fml.neoFormVersion 20231019.002635 --launchTarget forgeclient
+
         List<String> argsList = Stream.of(args).collect(Collectors.toList());
+        // NOTE: this is only true for NeoForge versions past 20.2.x
+        // early versions of NeoForge (for 1.20.1) are not supposed to be covered here
+        boolean isNeoForge = argsList.contains("--fml.neoForgeVersion");
+
         String mcVersion = argsList.get(argsList.indexOf("--fml.mcVersion") + 1);
         String forgeGroup = argsList.contains("--fml.forgeGroup") ? argsList.get(argsList.indexOf("--fml.forgeGroup") + 1) : "net.neoforged";
-        String forgeVersion = argsList.get(argsList.indexOf("--fml.forgeVersion") + 1);
-        String forgeFullVersion = mcVersion + "-" + forgeVersion;
+        String forgeArtifact = isNeoForge ? "neoforge" : "forge";
+        String forgeVersionKey = isNeoForge ? "--fml.neoForgeVersion" : "--fml.forgeVersion";
+        String forgeVersion = argsList.get(argsList.indexOf(forgeVersionKey) + 1);
+        String forgeFullVersion = isNeoForge ? forgeVersion : mcVersion + "-" + forgeVersion;
 
         IFileDetector detector = DetectorLoader.loadDetector();
         try {
-            Bootstrap.bootstrap(detector.getJvmArgs(forgeGroup, forgeFullVersion), detector.getMinecraftJar(mcVersion).getFileName().toString(), detector.getLibraryDir().toAbsolutePath().toString());
+            Bootstrap.bootstrap(detector.getJvmArgs(forgeGroup, forgeArtifact, forgeFullVersion), detector.getMinecraftJar(mcVersion).getFileName().toString(), detector.getLibraryDir().toAbsolutePath().toString());
         } catch (Throwable ignored) {
             // Avoid this bunch of hacks that nuke the whole wrapper.
         }
-        if (!detector.checkExtraFiles(forgeGroup, forgeFullVersion)) {
+        if (!detector.checkExtraFiles(forgeGroup, forgeArtifact, forgeFullVersion)) {
             System.out.println("Some extra libraries are missing! Running the installer to generate them now.");
 
             // Check installer jar.
-            Path installerJar = detector.getInstallerJar(forgeGroup, forgeFullVersion);
+            Path installerJar = detector.getInstallerJar(forgeGroup, forgeArtifact, forgeFullVersion);
             if (!IFileDetector.isFile(installerJar)) {
                 throw new RuntimeException("Unable to detect the forge installer!");
             }
@@ -54,7 +62,7 @@ public class Main {
             }
         }
 
-        Class<?> mainClass = ModuleUtil.setupBootstrapLauncher(Class.forName(detector.getMainClass(forgeGroup, forgeFullVersion)));
+        Class<?> mainClass = ModuleUtil.setupBootstrapLauncher(Class.forName(detector.getMainClass(forgeGroup, forgeArtifact, forgeFullVersion)));
         mainClass.getMethod("main", String[].class).invoke(null, new Object[] { args });
     }
 }

--- a/src/main/java/io/github/zekerzhayard/forgewrapper/installer/detector/IFileDetector.java
+++ b/src/main/java/io/github/zekerzhayard/forgewrapper/installer/detector/IFileDetector.java
@@ -62,10 +62,11 @@ public interface IFileDetector {
 
     /**
      * @param forgeGroup Forge package group (e.g. net.minecraftforge).
+     * @param forgeArtifact Forge package artifact (e.g. forge).
      * @param forgeFullVersion Forge full version (e.g. 1.14.4-28.2.0).
      * @return The forge installer jar path. It can also be defined by JVM argument "-Dforgewrapper.installer=&lt;installer-path&gt;".
      */
-    default Path getInstallerJar(String forgeGroup, String forgeFullVersion) {
+    default Path getInstallerJar(String forgeGroup, String forgeArtifact, String forgeFullVersion) {
         String installer = System.getProperty("forgewrapper.installer");
         if (installer != null) {
             return Paths.get(installer).toAbsolutePath();
@@ -87,11 +88,12 @@ public interface IFileDetector {
 
     /**
      * @param forgeGroup Forge package group (e.g. net.minecraftforge).
+     * @param forgeArtifact Forge package artifact (e.g. forge).
      * @param forgeFullVersion Forge full version (e.g. 1.14.4-28.2.0).
      * @return The list of jvm args.
      */
-    default List<String> getJvmArgs(String forgeGroup, String forgeFullVersion) {
-        return this.getDataFromInstaller(forgeGroup, forgeFullVersion, "version.json", e -> {
+    default List<String> getJvmArgs(String forgeGroup, String forgeArtifact, String forgeFullVersion) {
+        return this.getDataFromInstaller(forgeGroup, forgeArtifact, forgeFullVersion, "version.json", e -> {
             JsonElement element = getElement(e.getAsJsonObject().getAsJsonObject("arguments"), "jvm");
             List<String> args = new ArrayList<>();
             if (!element.equals(JsonNull.INSTANCE)) {
@@ -103,25 +105,27 @@ public interface IFileDetector {
 
     /**
      * @param forgeGroup Forge package group (e.g. net.minecraftforge).
+     * @param forgeArtifact Forge package artifact (e.g. forge).
      * @param forgeFullVersion Forge full version (e.g. 1.14.4-28.2.0).
      * @return The main class.
      */
-    default String getMainClass(String forgeGroup, String forgeFullVersion) {
-        return this.getDataFromInstaller(forgeGroup, forgeFullVersion, "version.json", e -> e.getAsJsonObject().getAsJsonPrimitive("mainClass").getAsString());
+    default String getMainClass(String forgeGroup, String forgeArtifact, String forgeFullVersion) {
+        return this.getDataFromInstaller(forgeGroup, forgeArtifact, forgeFullVersion, "version.json", e -> e.getAsJsonObject().getAsJsonPrimitive("mainClass").getAsString());
     }
 
     /**
      * @param forgeGroup Forge package group (e.g. net.minecraftforge).
+     * @param forgeArtifact Forge package artifact (e.g. forge).
      * @param forgeFullVersion Forge full version (e.g. 1.14.4-28.2.0).
      * @return The json object in the-installer-jar-->install_profile.json-->data-->xxx-->client.
      */
-    default JsonObject getInstallProfileExtraData(String forgeGroup, String forgeFullVersion) {
-        return this.getDataFromInstaller(forgeGroup, forgeFullVersion, "install_profile.json", e -> e.getAsJsonObject().getAsJsonObject("data"));
+    default JsonObject getInstallProfileExtraData(String forgeGroup, String forgeArtifact, String forgeFullVersion) {
+        return this.getDataFromInstaller(forgeGroup, forgeArtifact, forgeFullVersion, "install_profile.json", e -> e.getAsJsonObject().getAsJsonObject("data"));
     }
 
     @SuppressWarnings("deprecation")
-    default <R> R getDataFromInstaller(String forgeGroup, String forgeFullVersion, String entry, Function<JsonElement, R> function) {
-        Path installer = this.getInstallerJar(forgeGroup, forgeFullVersion);
+    default <R> R getDataFromInstaller(String forgeGroup, String forgeArtifact, String forgeFullVersion, String entry, Function<JsonElement, R> function) {
+        Path installer = this.getInstallerJar(forgeGroup, forgeArtifact, forgeFullVersion);
         if (isFile(installer)) {
             try (ZipFile zf = new ZipFile(installer.toFile())) {
                 ZipEntry ze = zf.getEntry(entry);
@@ -145,11 +149,12 @@ public interface IFileDetector {
     /**
      * Check all cached files.
      * @param forgeGroup Forge package group (e.g. net.minecraftforge).
+     * @param forgeArtifact Forge package artifact (e.g. forge).
      * @param forgeFullVersion Forge full version (e.g. 1.14.4-28.2.0).
      * @return True represents all files are ready.
      */
-    default boolean checkExtraFiles(String forgeGroup, String forgeFullVersion) {
-        JsonObject jo = this.getInstallProfileExtraData(forgeGroup, forgeFullVersion);
+    default boolean checkExtraFiles(String forgeGroup, String forgeArtifact, String forgeFullVersion) {
+        JsonObject jo = this.getInstallProfileExtraData(forgeGroup, forgeArtifact, forgeFullVersion);
         if (jo != null) {
             Map<String, Path> libsMap = new HashMap<>();
             Map<String, String> hashMap = new HashMap<>();

--- a/src/main/java/io/github/zekerzhayard/forgewrapper/installer/detector/MultiMCFileDetector.java
+++ b/src/main/java/io/github/zekerzhayard/forgewrapper/installer/detector/MultiMCFileDetector.java
@@ -27,14 +27,14 @@ public class MultiMCFileDetector implements IFileDetector {
     }
 
     @Override
-    public Path getInstallerJar(String forgeGroup, String forgeFullVersion) {
-        Path path = IFileDetector.super.getInstallerJar(forgeGroup, forgeFullVersion);
+    public Path getInstallerJar(String forgeGroup, String forgeArtifact, String forgeFullVersion) {
+        Path path = IFileDetector.super.getInstallerJar(forgeGroup, forgeArtifact, forgeFullVersion);
         if (path == null) {
             if (this.installerJar == null) {
                 Path installerBase = this.getLibraryDir();
                 for (String dir : forgeGroup.split("\\."))
                     installerBase = installerBase.resolve(dir);
-                this.installerJar = installerBase.resolve("forge").resolve(forgeFullVersion).resolve("forge-" + forgeFullVersion + "-installer.jar").toAbsolutePath();
+                this.installerJar = installerBase.resolve(forgeArtifact).resolve(forgeFullVersion).resolve(forgeArtifact + "-" + forgeFullVersion + "-installer.jar").toAbsolutePath();
             }
             return this.installerJar;
         }


### PR DESCRIPTION
Closes #15

Main changes:
- Detect new NeoForge and store package artifact accordingly
- Use detected artifactId instead of hardcoded `forge` artifact
- Take `fml.neoForgeVersion` as the full version instead of building it out of the Minecraft version