### PR TITLE
add command line argument to skip hash checks

### DIFF
--- a/src/main/java/io/github/zekerzhayard/forgewrapper/installer/Installer.java
+++ b/src/main/java/io/github/zekerzhayard/forgewrapper/installer/Installer.java
@@ -24,16 +24,16 @@ import net.minecraftforge.installer.json.Version;
 
 public class Installer {
     private static InstallV1Wrapper wrapper;
-    private static InstallV1Wrapper getWrapper(File librariesDir) {
+    private static InstallV1Wrapper getWrapper(File librariesDir, boolean skipHashCheck) {
         if (wrapper == null) {
-            wrapper = new InstallV1Wrapper(Util.loadInstallProfile(), librariesDir);
+            wrapper = new InstallV1Wrapper(Util.loadInstallProfile(), librariesDir, skipHashCheck);
         }
         return wrapper;
     }
 
-    public static Map<String, Object> getData(File librariesDir) {
+    public static Map<String, Object> getData(File librariesDir, boolean skipHashCheck) {
         Map<String, Object> data = new HashMap<>();
-        Version0 version = Version0.loadVersion(getWrapper(librariesDir));
+        Version0 version = Version0.loadVersion(getWrapper(librariesDir, skipHashCheck));
         data.put("mainClass", version.getMainClass());
         data.put("jvmArgs", version.getArguments().getJvm());
         data.put("extraLibraries", getExtraLibraries(version));
@@ -79,15 +79,20 @@ public class Installer {
     public static class InstallV1Wrapper extends InstallV1 {
         protected Map<String, List<Processor>> processors = new HashMap<>();
         protected File librariesDir;
+        protected boolean skipHashCheck = false;
 
-        public InstallV1Wrapper(InstallV1 v1, File librariesDir) {
+        public InstallV1Wrapper(InstallV1 v1, File librariesDir, boolean skipHashCheck) {
             super(v1);
             this.serverJarPath = v1.getServerJarPath();
             this.librariesDir = librariesDir;
+            this.skipHashCheck = skipHashCheck;
         }
 
         @Override
         public List<Processor> getProcessors(String side) {
+            if (this.skipHashCheck){
+                 return new ArrayList<>();
+            }
             List<Processor> processor = this.processors.get(side);
             if (processor == null) {
                 checkProcessorFiles(processor = super.getProcessors(side), super.getData("client".equals(side)), this.librariesDir);

--- a/src/main/java/io/github/zekerzhayard/forgewrapper/installer/Main.java
+++ b/src/main/java/io/github/zekerzhayard/forgewrapper/installer/Main.java
@@ -24,6 +24,7 @@ public class Main {
         // NOTE: this is only true for NeoForge versions past 20.2.x
         // early versions of NeoForge (for 1.20.1) are not supposed to be covered here
         boolean isNeoForge = argsList.contains("--fml.neoForgeVersion");
+        boolean skipHashCheck = argsList.contains("--skipHashCheck");
 
         String mcVersion = argsList.get(argsList.indexOf("--fml.mcVersion") + 1);
         String forgeGroup = argsList.contains("--fml.forgeGroup") ? argsList.get(argsList.indexOf("--fml.forgeGroup") + 1) : "net.neoforged";
@@ -52,7 +53,7 @@ public class Main {
         }, ModuleUtil.getPlatformClassLoader())) {
             Class<?> installer = ucl.loadClass("io.github.zekerzhayard.forgewrapper.installer.Installer");
 
-            Map<String, Object> data = (Map<String, Object>) installer.getMethod("getData", File.class).invoke(null, detector.getLibraryDir().toFile());
+            Map<String, Object> data = (Map<String, Object>) installer.getMethod("getData", File.class, boolean.class).invoke(null, detector.getLibraryDir().toFile(), skipHashCheck);
             try {
                 Bootstrap.bootstrap((String[]) data.get("jvmArgs"), detector.getMinecraftJar(mcVersion).getFileName().toString(), detector.getLibraryDir().toAbsolutePath().toString());
             } catch (Throwable t) {


### PR DESCRIPTION
Address the compatibility issue with zlib-ng-compat, which is now shipped in place of zlib in various Linux distros. This change introduces an option to disable hash mismatches reported on processors.